### PR TITLE
Add option to log piped data

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,12 @@ Usage of tcpproxy:
   -ltls
     	tls/ssl between client and proxy
       
-  -rhots string
+  -rhost string
     	proxy remote address (default ":80")
       
   -rtls
     	tls/ssl between proxy and target
+
+  -log
+      log type (string, hex)
 ```

--- a/cmd/tcpproxy/main.go
+++ b/cmd/tcpproxy/main.go
@@ -7,7 +7,7 @@ import (
 	"net"
 	"os"
 
-	"github.com/kahlys/proxy"
+	"github.com/mbndr/proxy"
 )
 
 var (
@@ -17,6 +17,7 @@ var (
 	localCert  = flag.String("lcert", "", "proxy certificate x509 file for tls/ssl use")
 	localKey   = flag.String("lkey", "", "proxy key x509 file for tls/ssl use")
 	remoteTLS  = flag.Bool("rtls", false, "tls/ssl between proxy and target")
+	logType = flag.String("log", "", "log type (string, hex)")
 )
 
 func main() {
@@ -44,6 +45,16 @@ func main() {
 		p = proxy.NewServer(raddr, nil, &tls.Config{InsecureSkipVerify: true})
 	} else {
 		p = proxy.NewServer(raddr, nil, nil)
+	}
+
+	// set log type
+	switch *logType {
+	case "string":
+		p.LogType = proxy.LOG_STRING
+	case "hex":
+		p.LogType = proxy.LOG_HEX
+	default:
+		p.LogType = proxy.LOG_NONE
 	}
 
 	fmt.Println("Proxying from " + laddr.String() + " to " + p.Target.String())

--- a/cmd/tcpproxy/main.go
+++ b/cmd/tcpproxy/main.go
@@ -7,7 +7,7 @@ import (
 	"net"
 	"os"
 
-	"github.com/mbndr/proxy"
+	"github.com/kahlys/proxy"
 )
 
 var (


### PR DESCRIPTION
I implemented this for a personal project. If you find it useful you can merge this PR, otherwise close it.

A parameter `proxy -log <hex|string>` can be added to log all piped output (with src and dst address) in the preferred format.

The output looks like this for each pipe through:
```
192.168.5.101:3333 -> 192.168.5.102:4444: [transmitted data in hex or as string]
```